### PR TITLE
Move indent processing of comments to dedicated comment block

### DIFF
--- a/src/main/java/de/arrobait/antlers/format/AntlersAbstractBlock.java
+++ b/src/main/java/de/arrobait/antlers/format/AntlersAbstractBlock.java
@@ -1,0 +1,55 @@
+package de.arrobait.antlers.format;
+
+import com.intellij.formatting.Alignment;
+import com.intellij.formatting.Wrap;
+import com.intellij.formatting.templateLanguages.DataLanguageBlockWrapper;
+import com.intellij.formatting.templateLanguages.TemplateLanguageBlock;
+import com.intellij.formatting.templateLanguages.TemplateLanguageBlockFactory;
+import com.intellij.lang.ASTNode;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.codeStyle.CodeStyleSettings;
+import com.intellij.psi.formatter.xml.HtmlPolicy;
+import com.intellij.psi.tree.IElementType;
+import de.arrobait.antlers.psi.AntlersTypes;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public abstract class AntlersAbstractBlock extends TemplateLanguageBlock {
+
+    @NotNull
+    protected final HtmlPolicy myHtmlPolicy;
+
+    protected final ASTNode myNode;
+
+    public AntlersAbstractBlock(@NotNull ASTNode node,
+                                @Nullable Wrap wrap,
+                                @Nullable Alignment alignment,
+                                @NotNull TemplateLanguageBlockFactory blockFactory,
+                                @NotNull CodeStyleSettings customSettings,
+                                @Nullable List<DataLanguageBlockWrapper> foreignChildren,
+                                @NotNull HtmlPolicy policy) {
+        super(node, wrap, alignment, blockFactory, customSettings, foreignChildren);
+
+        myHtmlPolicy = policy;
+        myNode = node;
+    }
+
+    @Override
+    public boolean isIncomplete() {
+        boolean isIncomplete = super.isIncomplete();
+        return isIncomplete;
+    }
+
+    @Override
+    protected IElementType getTemplateTextElementType() {
+        // We ignore OUTER_CONTENT tokens since they get formatted by the templated language.
+        return AntlersTypes.OUTER_CONTENT;
+    }
+
+    @Override
+    public boolean isRequiredRange(TextRange range) {
+        return false;
+    }
+}

--- a/src/main/java/de/arrobait/antlers/format/AntlersCommentBlock.java
+++ b/src/main/java/de/arrobait/antlers/format/AntlersCommentBlock.java
@@ -1,0 +1,43 @@
+package de.arrobait.antlers.format;
+
+import com.intellij.formatting.Alignment;
+import com.intellij.formatting.Indent;
+import com.intellij.formatting.Wrap;
+import com.intellij.formatting.templateLanguages.DataLanguageBlockWrapper;
+import com.intellij.formatting.templateLanguages.TemplateLanguageBlockFactory;
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.codeStyle.CodeStyleSettings;
+import com.intellij.psi.formatter.xml.HtmlPolicy;
+import de.arrobait.antlers.psi.AntlersFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class AntlersCommentBlock extends AntlersAbstractBlock {
+
+    public AntlersCommentBlock(@NotNull ASTNode node,
+                               @Nullable Wrap wrap,
+                               @Nullable Alignment alignment,
+                               @NotNull TemplateLanguageBlockFactory blockFactory,
+                               @NotNull CodeStyleSettings customSettings,
+                               @Nullable List<DataLanguageBlockWrapper> foreignChildren,
+                               @NotNull HtmlPolicy policy) {
+        super(node, wrap, alignment, blockFactory, customSettings, foreignChildren, policy);
+    }
+
+    /**
+     * Only indent comment when they are not on the root level
+     * aka a direct child of the root node (file).
+     */
+    @Override
+    public Indent getIndent() {
+        PsiElement parent = myNode.getTreeParent().getPsi();
+        if (!(parent instanceof AntlersFile)) {
+            return Indent.getNormalIndent();
+        }
+
+        return Indent.getNoneIndent();
+    }
+}

--- a/src/main/java/de/arrobait/antlers/format/AntlersFormattingModelBuilder.java
+++ b/src/main/java/de/arrobait/antlers/format/AntlersFormattingModelBuilder.java
@@ -11,6 +11,7 @@ import com.intellij.psi.formatter.DocumentBasedFormattingModel;
 import com.intellij.psi.formatter.FormattingDocumentModelImpl;
 import com.intellij.psi.formatter.xml.HtmlPolicy;
 import com.intellij.psi.templateLanguages.SimpleTemplateLanguageFormattingModelBuilder;
+import com.intellij.psi.tree.IElementType;
 import de.arrobait.antlers.psi.AntlersCustomElementTypes;
 import de.arrobait.antlers.psi.AntlersFile;
 import de.arrobait.antlers.psi.AntlersTokenSets;
@@ -18,6 +19,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+
+import static de.arrobait.antlers.psi.AntlersTypes.COMMENT_BLOCK;
 
 public class AntlersFormattingModelBuilder extends TemplateLanguageFormattingModelBuilder {
 
@@ -54,9 +57,17 @@ public class AntlersFormattingModelBuilder extends TemplateLanguageFormattingMod
                                                              @NotNull CodeStyleSettings settings) {
         final FormattingDocumentModel documentModel = FormattingDocumentModelImpl.createOn(node.getPsi().getContainingFile());
         HtmlPolicy policy = new HtmlPolicy(settings, documentModel);
-        return AntlersTokenSets.NODES.contains(node.getElementType()) ?
-                new AntlersNodeBlock(node, wrap, alignment, this, settings, foreignChildren, policy) :
-                new AntlersBlock(node, wrap, alignment, this, settings, foreignChildren, policy);
+        TemplateLanguageBlock block;
+        IElementType elementType = node.getElementType();
+        if (AntlersTokenSets.NODES.contains(elementType)) {
+            block = new AntlersNodeBlock(node, wrap, alignment, this, settings, foreignChildren, policy);
+        } else if (elementType == COMMENT_BLOCK) {
+            block = new AntlersCommentBlock(node, wrap, alignment, this, settings, foreignChildren, policy);
+        } else {
+            block = new AntlersBlock(node, wrap, alignment, this, settings, foreignChildren, policy);
+        }
+
+        return block;
     }
 
     /**


### PR DESCRIPTION
Introducing a base class which keeps all the common settings and let `AntlersBlock` and the new `AntlersCommentBlock` inherit from it.

Move the comment indent settings from `AntlersBlock` to `AntlersCommentBlock`.