### PR TITLE
Improve the formatting settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## [Unreleased]
 
 ### Added
-- Add formatting
+- Add formatting and formatting settings
 - Add checkout action to `ReleaseDraft` step
 - New modifiers
   - `add_query_param`

--- a/src/main/java/de/arrobait/antlers/format/AntlersAbstractBlock.java
+++ b/src/main/java/de/arrobait/antlers/format/AntlersAbstractBlock.java
@@ -21,7 +21,7 @@ public abstract class AntlersAbstractBlock extends TemplateLanguageBlock {
     @NotNull
     protected final HtmlPolicy myHtmlPolicy;
 
-    protected final ASTNode myNode;
+    protected final AntlersBlockContext myContext;
 
     public AntlersAbstractBlock(@NotNull ASTNode node,
                                 @Nullable Wrap wrap,
@@ -29,11 +29,12 @@ public abstract class AntlersAbstractBlock extends TemplateLanguageBlock {
                                 @NotNull TemplateLanguageBlockFactory blockFactory,
                                 @NotNull CodeStyleSettings customSettings,
                                 @Nullable List<DataLanguageBlockWrapper> foreignChildren,
+                                @Nullable AntlersBlockContext context,
                                 @NotNull HtmlPolicy policy) {
         super(node, wrap, alignment, blockFactory, customSettings, foreignChildren);
 
+        myContext = context;
         myHtmlPolicy = policy;
-        myNode = node;
     }
 
     @Override

--- a/src/main/java/de/arrobait/antlers/format/AntlersBlock.java
+++ b/src/main/java/de/arrobait/antlers/format/AntlersBlock.java
@@ -28,18 +28,17 @@ public class AntlersBlock extends AntlersAbstractBlock {
 
     protected final AntlersWrappingProcessor myWrappingProcessor;
 
-    private CodeStyleSettings myCustomSettings;
-
     public AntlersBlock(@NotNull ASTNode node,
                         @Nullable Wrap wrap,
                         @Nullable Alignment alignment,
                         @NotNull TemplateLanguageBlockFactory blockFactory,
                         @NotNull CodeStyleSettings customSettings,
                         @Nullable List<DataLanguageBlockWrapper> foreignChildren,
+                        @NotNull AntlersBlockContext context,
                         @NotNull HtmlPolicy policy) {
-        super(node, wrap, alignment, blockFactory, customSettings, foreignChildren, policy);
+        super(node, wrap, alignment, blockFactory, customSettings, foreignChildren, context, policy);
 
-        mySpacingProcessor = new AntlersSpacingProcessor(node, customSettings);
+        mySpacingProcessor = new AntlersSpacingProcessor(node, context);
         myWrappingProcessor = new AntlersWrappingProcessor(node);
     }
 

--- a/src/main/java/de/arrobait/antlers/format/AntlersBlockContext.java
+++ b/src/main/java/de/arrobait/antlers/format/AntlersBlockContext.java
@@ -13,7 +13,7 @@ public class AntlersBlockContext {
         this.antlersCodeStyleSettings = settings.getCommonSettings(AntlersLanguage.INSTANCE);
     }
 
-    public CodeStyleSettings getMySettings() {
+    public CodeStyleSettings getSettings() {
         return mySettings;
     }
 

--- a/src/main/java/de/arrobait/antlers/format/AntlersCommentBlock.java
+++ b/src/main/java/de/arrobait/antlers/format/AntlersCommentBlock.java
@@ -23,8 +23,9 @@ public class AntlersCommentBlock extends AntlersAbstractBlock {
                                @NotNull TemplateLanguageBlockFactory blockFactory,
                                @NotNull CodeStyleSettings customSettings,
                                @Nullable List<DataLanguageBlockWrapper> foreignChildren,
+                               @NotNull AntlersBlockContext context,
                                @NotNull HtmlPolicy policy) {
-        super(node, wrap, alignment, blockFactory, customSettings, foreignChildren, policy);
+        super(node, wrap, alignment, blockFactory, customSettings, foreignChildren, context, policy);
     }
 
     /**

--- a/src/main/java/de/arrobait/antlers/format/AntlersFileIndentOptionsProvider.java
+++ b/src/main/java/de/arrobait/antlers/format/AntlersFileIndentOptionsProvider.java
@@ -5,7 +5,6 @@ import com.intellij.psi.codeStyle.CodeStyleSettings;
 import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
 import com.intellij.psi.codeStyle.CommonCodeStyleSettings.IndentOptions;
 import com.intellij.psi.codeStyle.FileIndentOptionsProvider;
-import de.arrobait.antlers.codeStyle.AntlersCodeStyleSettings;
 import de.arrobait.antlers.psi.AntlersFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -14,7 +13,6 @@ public class AntlersFileIndentOptionsProvider extends FileIndentOptionsProvider 
     @Override
     public CommonCodeStyleSettings.@Nullable IndentOptions getIndentOptions(@NotNull CodeStyleSettings settings, @NotNull PsiFile file) {
         if (file instanceof AntlersFile) {
-            AntlersCodeStyleSettings antlersSettings = settings.getCustomSettings(AntlersCodeStyleSettings.class);
             IndentOptions options = settings.getLanguageIndentOptions(file.getLanguage());
             if (options != null) {
                 options = (IndentOptions) options.clone();

--- a/src/main/java/de/arrobait/antlers/format/AntlersFormattingModelBuilder.java
+++ b/src/main/java/de/arrobait/antlers/format/AntlersFormattingModelBuilder.java
@@ -59,12 +59,14 @@ public class AntlersFormattingModelBuilder extends TemplateLanguageFormattingMod
         HtmlPolicy policy = new HtmlPolicy(settings, documentModel);
         TemplateLanguageBlock block;
         IElementType elementType = node.getElementType();
+        AntlersBlockContext context = new AntlersBlockContext(settings);
+
         if (AntlersTokenSets.NODES.contains(elementType)) {
-            block = new AntlersNodeBlock(node, wrap, alignment, this, settings, foreignChildren, policy);
+            block = new AntlersNodeBlock(node, wrap, alignment, this, settings, foreignChildren, context, policy);
         } else if (elementType == COMMENT_BLOCK) {
-            block = new AntlersCommentBlock(node, wrap, alignment, this, settings, foreignChildren, policy);
+            block = new AntlersCommentBlock(node, wrap, alignment, this, settings, foreignChildren, context, policy);
         } else {
-            block = new AntlersBlock(node, wrap, alignment, this, settings, foreignChildren, policy);
+            block = new AntlersBlock(node, wrap, alignment, this, settings, foreignChildren, context, policy);
         }
 
         return block;

--- a/src/main/java/de/arrobait/antlers/format/AntlersNodeBlock.java
+++ b/src/main/java/de/arrobait/antlers/format/AntlersNodeBlock.java
@@ -28,8 +28,9 @@ public class AntlersNodeBlock extends AntlersBlock {
                             @NotNull TemplateLanguageBlockFactory blockFactory,
                             @NotNull CodeStyleSettings settings,
                             @Nullable List<DataLanguageBlockWrapper> foreignChildren,
+                            @NotNull AntlersBlockContext context,
                             @NotNull HtmlPolicy policy) {
-        super(node, wrap, alignment, blockFactory, settings, foreignChildren, policy);
+        super(node, wrap, alignment, blockFactory, settings, foreignChildren, context, policy);
 
         myChildAttributeAlignment = Alignment.createAlignment();
     }

--- a/src/main/java/de/arrobait/antlers/format/settings/AntlersCodeStyleSettings.java
+++ b/src/main/java/de/arrobait/antlers/format/settings/AntlersCodeStyleSettings.java
@@ -1,14 +1,15 @@
-package de.arrobait.antlers.codeStyle;
+package de.arrobait.antlers.format.settings;
 
 import com.intellij.psi.codeStyle.CodeStyleSettings;
 import com.intellij.psi.codeStyle.CustomCodeStyleSettings;
+import de.arrobait.antlers.AntlersLanguage;
 
 public class AntlersCodeStyleSettings extends CustomCodeStyleSettings {
-    protected AntlersCodeStyleSettings(CodeStyleSettings container) {
-        super("AntlersCodeStyleSettings", container);
-    }
-
     public boolean SPACE_AFTER_AND_BEFORE_ANTLERS_DELIMITERS = true;
     public boolean SPACE_AROUND_MODIFIER_PIPE = true;
     public boolean SPACE_AROUND_OPERATORS = true;
+
+    protected AntlersCodeStyleSettings(CodeStyleSettings container) {
+        super(AntlersLanguage.INSTANCE.getID(), container);
+    }
 }

--- a/src/main/java/de/arrobait/antlers/format/settings/AntlersCodeStyleSettingsProvider.java
+++ b/src/main/java/de/arrobait/antlers/format/settings/AntlersCodeStyleSettingsProvider.java
@@ -1,4 +1,4 @@
-package de.arrobait.antlers.codeStyle;
+package de.arrobait.antlers.format.settings;
 
 import com.intellij.application.options.CodeStyleAbstractConfigurable;
 import com.intellij.application.options.CodeStyleAbstractPanel;

--- a/src/main/java/de/arrobait/antlers/format/settings/AntlersLanguageCodeStyleSettingsProvider.java
+++ b/src/main/java/de/arrobait/antlers/format/settings/AntlersLanguageCodeStyleSettingsProvider.java
@@ -1,4 +1,4 @@
-package de.arrobait.antlers.codeStyle;
+package de.arrobait.antlers.format.settings;
 
 import com.intellij.application.options.CodeStyleAbstractPanel;
 import com.intellij.application.options.IndentOptionsEditor;

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -82,10 +82,10 @@
 
         <!-- Formatting -->
         <codeStyleSettingsProvider
-                implementation="de.arrobait.antlers.codeStyle.AntlersCodeStyleSettingsProvider"/>
+                implementation="de.arrobait.antlers.format.settings.AntlersCodeStyleSettingsProvider"/>
 
         <langCodeStyleSettingsProvider
-                implementation="de.arrobait.antlers.codeStyle.AntlersLanguageCodeStyleSettingsProvider"/>
+                implementation="de.arrobait.antlers.format.settings.AntlersLanguageCodeStyleSettingsProvider"/>
 
         <lang.formatter
                 language="Antlers"

--- a/src/test/java/de/arrobait/antlers/format/FormatterTestSettings.java
+++ b/src/test/java/de/arrobait/antlers/format/FormatterTestSettings.java
@@ -2,7 +2,10 @@ package de.arrobait.antlers.format;
 
 import com.intellij.ide.highlighter.HtmlFileType;
 import com.intellij.psi.codeStyle.CodeStyleSettings;
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
 import com.intellij.psi.formatter.xml.HtmlCodeStyleSettings;
+import de.arrobait.antlers.AntlersLanguage;
+import de.arrobait.antlers.format.settings.AntlersCodeStyleSettings;
 
 /**
  * Provides a setup and tear down for tests to use to set up the app test fixture with
@@ -14,6 +17,7 @@ public class FormatterTestSettings {
     private int myPrevIndentSize;
     private String myPrevDoNotIndentSetting;
     private int myPrevKeepBlankLines;
+    private boolean myPrevKeepLineBreaks;
 
     public FormatterTestSettings(CodeStyleSettings codeStyleSettings) {
         mySettings = codeStyleSettings;
@@ -26,8 +30,11 @@ public class FormatterTestSettings {
         myPrevIndentSize = mySettings.getIndentOptions(HtmlFileType.INSTANCE).INDENT_SIZE;
         mySettings.getIndentOptions(HtmlFileType.INSTANCE).INDENT_SIZE = 4;
 
-        myPrevKeepBlankLines = getHtmlCodeStyleSettings().HTML_KEEP_BLANK_LINES;
-        getHtmlCodeStyleSettings().HTML_KEEP_BLANK_LINES = 0;
+        myPrevKeepLineBreaks = getAntlersStyleSettings().KEEP_LINE_BREAKS;
+        getAntlersStyleSettings().KEEP_BLANK_LINES_IN_CODE = 1;
+
+        myPrevKeepBlankLines = getAntlersStyleSettings().KEEP_BLANK_LINES_IN_CODE;
+        getAntlersStyleSettings().KEEP_BLANK_LINES_IN_CODE = 1;
 
         myPrevDoNotIndentSetting = getHtmlCodeStyleSettings().HTML_DO_NOT_INDENT_CHILDREN_OF;
         getHtmlCodeStyleSettings().HTML_DO_NOT_INDENT_CHILDREN_OF = "";
@@ -35,11 +42,16 @@ public class FormatterTestSettings {
 
     public void tearDown() {
         mySettings.getIndentOptions(HtmlFileType.INSTANCE).INDENT_SIZE = myPrevIndentSize;
+        getAntlersStyleSettings().KEEP_BLANK_LINES_IN_CODE = myPrevKeepBlankLines;
+        getAntlersStyleSettings().KEEP_LINE_BREAKS = myPrevKeepLineBreaks;
         getHtmlCodeStyleSettings().HTML_DO_NOT_INDENT_CHILDREN_OF = myPrevDoNotIndentSetting;
-        getHtmlCodeStyleSettings().HTML_KEEP_BLANK_LINES = myPrevKeepBlankLines;
     }
 
     private HtmlCodeStyleSettings getHtmlCodeStyleSettings() {
         return mySettings.getCustomSettings(HtmlCodeStyleSettings.class);
+    }
+
+    private CommonCodeStyleSettings getAntlersStyleSettings() {
+        return mySettings.getCommonSettings(AntlersLanguage.INSTANCE);
     }
 }

--- a/src/test/testData/formatter/HTML_expected.antlers.html
+++ b/src/test/testData/formatter/HTML_expected.antlers.html
@@ -4,6 +4,7 @@
         <title>{{ site:title }}</title>
         <title>@{{ site:title }}</title>
         <style>
+
         </style>
         <style>
             body {
@@ -23,7 +24,9 @@
         </script>
     </head>
     <body>
+
         <h1>This is a heading</h1>
         <p>This is a paragraph.</p>
+
     </body>
 </html>


### PR DESCRIPTION
- use the Context model as a data object which keeps the different CodeStyleSettings
- move all files related to the settings to `format/settings`.
- Fixed an spacing issue regarding `:` in tenary condition