### PR TITLE
Do not add `.antlers.html` twice on "New File"-Dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 ### Changed
 - Optimize the Lexer by removing duplicate actions and use multiple states.
 
+### Fixed
+- When creating a new Antles file via _New File_-Dialog do not append `.antlers.html` when the user already provides the extension in the dialog.
+
 ## [0.0.5] - 2023-02-24
 
 ### Added

--- a/src/main/java/de/arrobait/antlers/file/CreateNewAntlersFileFromTemplateHandler.java
+++ b/src/main/java/de/arrobait/antlers/file/CreateNewAntlersFileFromTemplateHandler.java
@@ -12,11 +12,16 @@ public class CreateNewAntlersFileFromTemplateHandler extends DefaultCreateFromTe
 
     @Override
     protected String checkAppendExtension(String fileName, @NotNull FileTemplate template) {
-        final String suggestedFileNameEnd = "." + AntlersFileType.DEFAULT_EXTENSION;
+        final String suggestedFileNameEnd = AntlersFileType.DOT_DEFAULT_EXTENSION;
+
+        if (fileName.endsWith(suggestedFileNameEnd)) {
+            return fileName;
+        }
 
         if (template.getName().endsWith("antlers")) {
             fileName += suggestedFileNameEnd;
         }
+
         return fileName;
     }
 }


### PR DESCRIPTION
Creating a new file can be done via the "New File"-Dialog by entering just the name. The extension is added by the plugin. However, if you entered the filename including the extension, it was added twice. This patch will correct that.