### PR TITLE
Improve Lexer readibility and performance 

### DIFF
--- a/src/main/gen/de/arrobait/antlers/grammar/AntlersLexer.java
+++ b/src/main/gen/de/arrobait/antlers/grammar/AntlersLexer.java
@@ -2959,9 +2959,7 @@ public class AntlersLexer implements FlexLexer {
 
                 // First we need to remove the matched `{{` characters from the match and put it back to the input string, so
                 // that the lexer can lex it again in a dedicated state.
-                while(yylength() > 0 && yytext().subSequence(yylength() - 1, yylength()).toString().equals("{")) {
-                    yypushback(1);
-                }
+                yypushback(2);
 
                 // Here we check if the char right before the `{{` is a `@`. If so, this is an escaped node, otherwise a
                 // regular Antlers node.

--- a/src/main/java/de/arrobait/antlers/grammar/AntlersLexer.flex
+++ b/src/main/java/de/arrobait/antlers/grammar/AntlersLexer.flex
@@ -110,9 +110,7 @@ FLOAT=[0-9]*\.[0-9]+([eE][-+]?[0-9]+)?|[0-9]+[eE][-+]?[0-9]+
 
                 // First we need to remove the matched `{{` characters from the match and put it back to the input string, so
                 // that the lexer can lex it again in a dedicated state.
-                while(yylength() > 0 && yytext().subSequence(yylength() - 1, yylength()).toString().equals("{")) {
-                    yypushback(1);
-                }
+                yypushback(2);
 
                 // Here we check if the char right before the `{{` is a `@`. If so, this is an escaped node, otherwise a
                 // regular Antlers node.


### PR DESCRIPTION
Remove a loop which loops backbackwards through the matched content and checks every char if it is a `{` to put it back into the input stream. As we have everytime two `{` in the matched string we can just use `yypushback(2)` to get the same result. This is easier to read and does not need to cast the stream to a string.
